### PR TITLE
Allow building on latest a3x-roms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 export TARGET :=	foodfight
 export SFILES :=	crt0.s
 export CFILES :=	main.c
+
+ARCH := -m68000
 include ../ass_romrules

--- a/crt0.s
+++ b/crt0.s
@@ -4,7 +4,7 @@
 	.asciz	"Food Fight"
 	.align	32
 	.long	0	//let ASSFIX set this.
-	.ascii	"FRN0"
+	.ascii	"FUDw"
 	.byte	0	//reserved
 	#include "../crt0.s"
 	TARGET_A3X = 1

--- a/main.c
+++ b/main.c
@@ -302,7 +302,6 @@ int main(void)
 	// Register our interrupt handlers
 	interface->VBlank = VBlankHandler;
 	interface->HBlank = HBlankHandler;
-	inton();
 
 	// Start the game!
 	FFEntry();

--- a/rom.s
+++ b/rom.s
@@ -22245,7 +22245,7 @@ FFVBlankHandler:
 
 .if TARGET_A3X
 
-	.org 0x10000
+	.org 0x20000
 
 	.global FFEntry
 	.global VBlankHandler


### PR DESCRIPTION
* Default target is m68030, but this is m68000-specific code.
* ROM starts at 0x20000 now.
* `inton()` is removed.
* I'm not sure why it wants to reapply the game ID change.